### PR TITLE
Improve long press handling on dice

### DIFF
--- a/components/Die.js
+++ b/components/Die.js
@@ -74,6 +74,11 @@ function Die({ die, draggable = false, onDragStart, onDragEnd, onDrag, onClick, 
         setDragStartPos({ x: touch.clientX, y: touch.clientY });
         setIsDragging(false);
 
+        // Select immediately so long presses still register
+        if (onClick) {
+            onClick(die);
+        }
+
         // Prevent default to avoid scrolling
         e.preventDefault();
     };


### PR DESCRIPTION
## Summary
- update mobile touch logic so dice select on touch start

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879d0076ddc8330b6b2230badb9acd9