### PR TITLE
Improve long press handling on dice

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -569,6 +569,9 @@ body {
     cursor: grab;
     transition: transform 0.1s ease;
     touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 .die.placed-die {


### PR DESCRIPTION
## Summary
- update mobile touch logic so long press selects die without disrupting drag
- disable text selection on dice to prevent copy/paste menu
- ensure long press release doesn't toggle selection

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879d0076ddc8330b6b2230badb9acd9