### PR TITLE
Fix setup screen scrolling

### DIFF
--- a/components/GameSetup.js
+++ b/components/GameSetup.js
@@ -302,7 +302,7 @@ function GameSetup({ onStartGame, onBack, preservedPlayerSetup }) {
           </div>
           <div>
             <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Configure Bays</h3>
-            <div className="space-y-2 max-h-[calc(100vh-400px)] min-h-[100px] overflow-y-auto pr-1 custom-scrollbar">
+            <div className="space-y-2 pr-1">
               {players.map((player, index) => (
                 <div key={player.id} className="p-3 border rounded-md bg-slate-50 dark:bg-slate-700/60">
                   <div className="flex space-x-3">

--- a/pages/index.js
+++ b/pages/index.js
@@ -976,7 +976,7 @@ export default function Home() {
             )}
 
             {gameState === 'setup' && (
-                <div className="fixed inset-0 bg-black">
+                <div className="fixed inset-0 bg-black overflow-y-auto">
                     <StarryBackground />
                     <div className="relative z-10 flex items-center justify-center min-h-screen p-4">
                         <GameSetup


### PR DESCRIPTION
## Summary
- allow entire setup overlay to scroll

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c579116bc833080bfa2aed597685c