### PR TITLE
Improve long press handling on dice

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -569,6 +569,9 @@ body {
     cursor: grab;
     transition: transform 0.1s ease;
     touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 .die.placed-die {


### PR DESCRIPTION
## Summary
- ignore synthetic click after long press so force press keeps die selected
- handle touch cancel by delegating to touch end

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879d0076ddc8330b6b2230badb9acd9