### PR TITLE
Improve long press handling on dice

### DIFF
--- a/components/Die.js
+++ b/components/Die.js
@@ -228,6 +228,7 @@ function Die({ die, draggable = false, onDragStart, onDragEnd, onDrag, onClick, 
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchEnd}
             onClick={handleClick}
             style={{
                 cursor: draggable && !die.placed ? 'grab' : (onClick ? 'pointer' : 'default')

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -569,6 +569,9 @@ body {
     cursor: grab;
     transition: transform 0.1s ease;
     touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 .die.placed-die {


### PR DESCRIPTION
## Summary
- undo overcomplicated long-press logic
- call the existing touch end handler when the touch is cancelled

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879d0076ddc8330b6b2230badb9acd9