### PR TITLE
Simplify mobile drop target lookup

### DIFF
--- a/components/Die.js
+++ b/components/Die.js
@@ -127,8 +127,10 @@ function Die({ die, draggable = false, onDragStart, onDragEnd, onDrag, onClick, 
                 onDrag({ clientX: touch.clientX, clientY: touch.clientY });
             }
 
-            // Find element under touch point
+            // Temporarily ignore this die to detect underlying drop target
+            e.target.style.pointerEvents = 'none';
             const elementBelow = document.elementFromPoint(touch.clientX, touch.clientY);
+            e.target.style.pointerEvents = '';
 
             // Clear previous drag-over states
             document.querySelectorAll('.drag-over').forEach(el => {
@@ -167,7 +169,10 @@ function Die({ die, draggable = false, onDragStart, onDragEnd, onDrag, onClick, 
             });
 
             const touch = e.changedTouches[0];
+            // Temporarily ignore this die to detect underlying drop target
+            e.target.style.pointerEvents = 'none';
             const elementBelow = document.elementFromPoint(touch.clientX, touch.clientY);
+            e.target.style.pointerEvents = '';
 
             // Find drop target
             let dropTarget = elementBelow;
@@ -228,6 +233,7 @@ function Die({ die, draggable = false, onDragStart, onDragEnd, onDrag, onClick, 
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchEnd}
             onClick={handleClick}
             style={{
                 cursor: draggable && !die.placed ? 'grab' : (onClick ? 'pointer' : 'default')

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -569,6 +569,9 @@ body {
     cursor: grab;
     transition: transform 0.1s ease;
     touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 .die.placed-die {


### PR DESCRIPTION
## Summary
- ensure element below dragged die is detected by ignoring pointer events

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879d0076ddc8330b6b2230badb9acd9